### PR TITLE
Reword the section on what HTTPS does not protect

### DIFF
--- a/pages/faq.md
+++ b/pages/faq.md
@@ -30,7 +30,7 @@ This is the same for all HTTP methods (GET, POST, PUT, etc.). The URL path and q
 
 ### What information does HTTPS _not_ protect?
 
-As shown above, the full domain or subdomain and the originating IP address remain unencrypted.
+While HTTPS encrypts the entire HTTP request and response, the DNS resolution and connection setup can reveal other information, such as the full domain or subdomain and the originating IP address, as shown above.
 
 Additionally, attackers can still analyze encrypted HTTPS traffic for "side channel" information. This can include the time spent on site, or the relative size of user input.
 


### PR DESCRIPTION
I'm not super happy with this rewording, since it's not absolutely accurate, yet also wordier. But it bothered me a bit that the section and the previous section imply that the HTTPS connection does not encrypt the hostname. It encrypts the hostname in the Host header or the fully qualified URI (if provided instead of a relative URI), since this is all part of the HTTP request itself. The domain/subdomain leakage comes from the DNS lookup and SNI and possibly the server certificate, depending on what names are specified.

I don't have a good solution here though. I think my suggested wording is marginally better, but I don't really like it either, and would be fine with it getting rejected.