### PR TITLE
Reword "benevolence of public networks"

### DIFF
--- a/index.md
+++ b/index.md
@@ -20,7 +20,7 @@ As our dependency on the internet has grown, the risk to users' privacy and safe
 
 Every unencrypted HTTP request reveals information about a user's behavior, and the interception and tracking of unencrypted browsing has become commonplace.
 
-Today, **there is no such thing as insensitive web traffic**, and public services should not depend on the benevolence of public networks.
+Today, **there is no such thing as insensitive web traffic**, and public services should not depend on the benevolence of network operators.
 
 When properly configured, HTTPS can provide a fast, secure connection that offers the level of privacy and reliability that users should expect from government web services.
 


### PR DESCRIPTION
"Public networks" does not seem like an entity that could have anthropomorphic qualities like benevolence. So, one solution is to switch to another term like "network operators", which while inexact, probably suffices.

Alternatively, perhaps we need to substitute "benevolence" out for another concept. I don't know a better one than "security". And I think that's probably confusing. Therefore, I've proposed switching out "public networks" for "network operators".