### PR TITLE
Note that forward secrecy will likely be required in TLS 1.3

### DIFF
--- a/pages/technical.md
+++ b/pages/technical.md
@@ -46,7 +46,9 @@ In non-forward-secret HTTPS connections, if an attacker records encrypted traffi
 
 In forward secret connections, the server and client create a temporary key for every new session that gets effectively "thrown away" after the session is complete. This means that even if the server's base private key is compromised, an attacker can't retroactively decrypt information.
 
-In TLS, forward secrecy is provided by choosing ciphersuites that include the [Ephemeral Diffie-Hellman (DHE)](https://en.wikipedia.org/wiki/Diffie–Hellman_key_exchange) and [Ephemeral Elliptic Curve Diffie–Hellman (ECDHE)](https://en.wikipedia.org/wiki/Elliptic_curve_Diffie%E2%80%93Hellman) key exchanges.
+In TLS, forward secrecy is provided by choosing ciphersuites that include the [DHE](https://en.wikipedia.org/wiki/Diffie–Hellman_key_exchange) and [ECDHE](https://en.wikipedia.org/wiki/Elliptic_curve_Diffie%E2%80%93Hellman) key exchanges.
+
+**Note:** Current drafts of TLS 1.3, the next version of TLS, require new connections to use employ forward secrecy by [removing support for RSA and static DH key exchange](https://tools.ietf.org/html/draft-ietf-tls-tls13-02#section-1.2).
 
 * **[The Pulse HTTPS dashboard for .gov domains](https://pulse.cio.gov/https/domains/)** will note when a domain offers little or no forward secrecy.
 * **[https.cio.gov is configured](https://www.ssllabs.com/ssltest/analyze.html?d=https.cio.gov)** to offer robust forward secrecy.


### PR DESCRIPTION
This adds a note to the [forward secrecy section](https://https.cio.gov/technical-guidelines/#forward-secrecy), which emphasizes that TLS 1.3 is likely to require forward secret ciphers for initial connections.

The language is meant to capture that this applies to 1-RTT mode (initial connections) rather than 0-RTT mode (resumed connections). It links to [the changelog section of `draft-02`](https://tools.ietf.org/html/draft-ietf-tls-tls13-02#section-1.2), where this change as introduced, so that the permalink is clear and relevant.

cc @jsha @richsalz