### PR TITLE
A page on Certificates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,8 @@ navigation:
   url: /guide/
 - text: FAQ
   url: /faq/
+- text: Certificates
+  url: /certificates/
 - text: Strict Transport Security
   url: /hsts/
 - text: Server Name Indication

--- a/pages/certificates.md
+++ b/pages/certificates.md
@@ -43,13 +43,13 @@ In general:
 
 * Certificates can be valid for anywhere from years to days. In general, **shorter-lived certificates offer a better security posture**, since the impact of key compromise is less severe. Automating the issuance and renewal of certificates is an overall best practice, and can make the adoption of shorter-lived certificates more practical.
 
-* Agencies should [avoid certificates signed with SHA-1](/technical-guidelines/#signature-algorithms), and CAs are forbidden from issuing them entirely as of January 1, 2016. **Any existing certificates signed with SHA-1 should be replaced immediately**, as browsers are quickly moving to remove support for the SHA-1 algorithm.
+* Agencies [should not use certificates signed with SHA-1](/technical-guidelines/#signature-algorithms), and CAs are forbidden from issuing them entirely as of January 1, 2016. **Any existing certificates signed with SHA-1 should be replaced immediately**, as browsers are quickly moving to remove support for the SHA-1 algorithm.
 
 As a general matter, certificates from any commercial CA will meet the few [NIST technical requirements](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf) that relate to certificates.
 
 ## What rules and oversight are certificate authorities subject to?
 
-Since 2012, all major browsers and certificate authorities participate in the **[CA/Browser Forum](https://cabforum.org). Though self-regulated, the CA/Browser Forum is effectively the governing body for publicly trusted certificate authorities.
+Since 2012, all major browsers and certificate authorities participate in the **[CA/Browser Forum](https://cabforum.org)**. Though self-regulated, the CA/Browser Forum is effectively the governing body for publicly trusted certificate authorities.
 
 The CA/B Forum produces the **[Baseline Requirements](https://cabforum.org/baseline-requirements-documents/)** (BRs), a set of technical and procedural policies that all CAs must adhere to. These policies are determined through a [formal voting process](https://cabforum.org/ballots/) of browsers and CAs. The BRs are enforced through a combination of technical measures, a system of standard third-party audits, and the overall community's attention to publicly visible certificates.
 

--- a/pages/certificates.md
+++ b/pages/certificates.md
@@ -5,14 +5,18 @@ permalink: /certificates/
 description: "Guidance around certificates for use in HTTPS."
 ---
 
-This page covers certificates, certificate authorities, and related frequently asked questions.
+Frequently asked questions and answers about HTTPS certificates and certificate authorities.
 
-* [Introduction](#introduction)
-* [Getting a certificate](#getting-a-certificate)
-* [Trusting certificate authorities](#signature-algorithms)
-* [Certificate FAQ](#certificate-faq)
+* [What are certificates and certificate authorities?](#what-are-certificates-and-certificate-authorities?)
+* [What kind of rules and oversight are certificate authorities subject to?](#what-kind-of-rules-and-oversight-are-certificate-authorities-subject-to?)
+* [Does the US government operate a publicly trusted certificate authority?](#does-the-us-government-operate-a-publicly-trusted-certificate-authority?)
+* [Are there federal restrictions on acceptable certificate authorities to use?](#are-there-federal-restrictions-on-acceptable-certificate-authorities-to-use?)
+* [Then how can I limit which CAs can issue certificates for a domain?](#then-how-can-i-limit-which-cas-can-issue-certificates-for-a-domain?)
 
-## Introduction
+  * [Certificate Transparency](#certificate-transparency)
+  * [HTTP Public Key Pinning](#http-public-key-pinning)
+
+## What are certificates and certificate authorities?
 
 Websites use **certificates** to create an HTTPS connection. When signed by a trusted **certificate authority** (CA), certificates give confidence to browsers that they are visiting the "real" website.
 
@@ -28,14 +32,80 @@ Web browsers are generally set to trust a pre-selected list of certificate autho
 
 When a website presents a certificate to a browser during an HTTPS connection, the browser uses the information and signature in the certificate to confirm that a CA it trusts has decided to trust the website the browser is connecting to.
 
-## Getting a certificate
+## What kind of rules and oversight are certificate authorities subject to?
 
+Since 2012, all major browsers and certificate authorities participate in the **[CA/Browser Forum](https://cabforum.org). Though self-regulated, the CA/Browser Forum is effectively the governing body for publicly trusted certificate authorities.
 
+The CA/B Forum produces the **[Baseline Requirements](https://cabforum.org/baseline-requirements-documents/)** (BRs), a set of technical and procedural policies that all CAs must adhere to. These policies are determined through a [formal voting process](https://cabforum.org/ballots/) of browsers and CAs. The BRs are enforced through a combination of technical measures, a system of standard third-party audits, and the overall community's attention to publicly visible certificates.
 
-## Certificate authorities
+The Baseline Requirements only constrain CAs -- they do not constrain browser behavior. Since browser vendors ultimately decide which certificates their browser will trust, they are the enforcers and adjudicators of BR violations. If a CA is found to be in violation of the BRs, a browser may punish that CA's ability to issue certificates that that browser will trust, up to and including expulsion from that browser's trust store.
 
+#### CA / Browser Resources
 
+* The current [Baseline Requirements](https://cabforum.org/baseline-requirements-documents/)
+* [CAB/Forum voting record](https://cabforum.org/ballots/)
+* [Mozilla revoking an ANSII intermediate](https://blog.mozilla.org/security/2013/12/09/revoking-trust-in-one-anssi-certificate/) after ANSII was found to have violated the BRs by inappropriately issuing a intermediate certificate for use in network monitoring.
+* [Google requiring Symantec to employ Certificate Transparency](https://googleonlinesecurity.blogspot.com/2015/10/sustaining-digital-certificate-security.html) after Symantec was found to have violated the BRs by misissuing certificates.
 
+## Does the US government operate a publicly trusted certificate authority?
 
-## Certificate FAQ
+No, not as of late 2015, and this is unlikely to change in the near future.
+
+The [Federal PKI](http://www.idmanagement.gov/federal-public-key-infrastructure) root is trusted by some browsers and operating systems, but is not contained in the [Mozilla Trusted Root Program](https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/policy/).
+s
+The Federal PKI has an [open application](https://bugzilla.mozilla.org/show_bug.cgi?id=478418) to the Mozilla Trusted Root Program. However, even if the Federal PKI's application is accepted, it will take a significant amount of time for the Federal PKI's root certificate to propagate widely around the world.
+
+## Are there federal restrictions on acceptable certificate authorities to use?
+
+There are no government-wide rules limiting what CAs federal domains can use.
+
+It is important to understand that, while there may be technical or business reasons for an agency to limit which CAs it uses, **there is no security benefit** to limiting CAs through internal policies alone. Browsers will trust certificates acquired from any publicly trusted CA, and so limiting CA usage internally will not limit the CAs from which an attacker may obtain a forged certificate.
+
+In practice, federal agencies use a wide variety of publicly trusted commercial CAs and privately trusted enterprise CAs to secure their web services.
+
+## Then how can I limit which CAs can issue certificates for a domain?
+
+There is no simple and 100% effective way to force all browsers to only trust certificates for your domain that have been issued from a certain CA. In general, the strength of HTTPS on today's internet depends on the overall standards, competence, and accountability of the entire CA system.
+
+However, domain owners have some options to reduce the risk or impact of misissued or fraudulent certificates:
+
+### Certificate Transparency
+
+**[Certificate Transparency](https://en.wikipedia.org/wiki/Certificate_Transparency)** (CT) allows domain owners to **detect missuance of certificates after the fact**.
+
+CT that allows CAs to publish some or all of the publicly trusted certificates that they issue to one or more public logs. Multiple organizations run CT logs, and it is possible to automatically monitor the logs for any certificates that are issued for any domains of interest.
+
+Comodo has released an [open source](https://github.com/crtsh) Certificate Transparency log viewer that they operate at [crt.sh](https://crt.sh). For example, it is possible to see [all recent certificates for whitehouse.gov](https://crt.sh/?q=whitehouse.gov), and [details of specific certificates](https://crt.sh/?id=7976268).
+
+The strength of Certificate Transparency increases as more CAs publish more certificates to public CT logs. Certificate Transparency is not currently a requirement for CAs -- however, as the use of CT increases, so does the viability of requiring CT for publicly issued certificates.
+
+#### Certificate Transparency Resources
+
+* [Google CT FAQ](https://www.certificate-transparency.org/faq)
+* [RFC 6962](https://tools.ietf.org/html/rfc6962), the official standard
+* [Wikipedia entry](https://en.wikipedia.org/wiki/Certificate_Transparency) for CT
+
+### HTTP Public Key Pinning
+
+**[HTTP Public Key Pinning](https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning)** (HPKP) allows domain owners to **tell browsers which certain keys, certs or CAs are trusted for their domain**.
+
+Domain owners can [use HPKP](https://developer.mozilla.org/en-US/docs/Web/Security/Public_Key_Pinning) in one of two ways:
+
+* The `Public-Key-Pins` header contains a list of SHA-256 hashes of public key information corresponding to client, intermediate, or root certificates. [Supporting browsers](http://caniuse.com/#search=hpkp) will hard-fail on certificates whose validated chain does not contain at least one of the listed keys. The domain owner can list a URI that browsers can POST to with error information when a hard-fail occurs.
+
+* The `Public-Key-Pins-Report-Only` HTTP header contains the same information, but will not fail or show users an error if a pinning violation is detected. Browsers will report detected violations to a given URI. This is
+
+Using `Public-Key-Pins` is **potentially dangerous**, and mistakes can lead to a site being rendered entirely inaccessible for weeks or months.
+
+Using `Public-Key-Pins-Report-Only` is very safe, and can provide useful information to detect potential certificate misissuance or attacks on users.
+
+Like [HSTS](/hsts/), HPKP only takes effect once the browser has visited the site once and received the HPKP header over a secure connection. HPKP preloading is possible, but as of 2015 this requires special manual coordination with browsers to do.
+
+#### HPKP Resources
+
+* [Guide to rolling out HPKP reporting](https://developers.google.com/web/updates/2015/09/HPKP-reporting-with-chrome-46?hl=en) by the Chrome team
+* [RFC 7469](https://tools.ietf.org/html/rfc7469), the official standard
+* [Discussion on GitHub](https://github.com/SSLMate/sslmate/issues/10) about HPKP strategy
+* [Wikipedia entry](https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning) for HPKP
+* [Browser support](http://caniuse.com/#search=hpkp) for HPKP
 

--- a/pages/certificates.md
+++ b/pages/certificates.md
@@ -1,0 +1,41 @@
+---
+layout: page
+title: Certificates
+permalink: /certificates/
+description: "Guidance around certificates for use in HTTPS."
+---
+
+This page covers certificates, certificate authorities, and related frequently asked questions.
+
+* [Introduction](#introduction)
+* [Getting a certificate](#getting-a-certificate)
+* [Trusting certificate authorities](#signature-algorithms)
+* [Certificate FAQ](#certificate-faq)
+
+## Introduction
+
+Websites use **certificates** to create an HTTPS connection. When signed by a trusted **certificate authority** (CA), certificates give confidence to browsers that they are visiting the "real" website.
+
+Technically, a certificate is a file that contains:
+
+* The domain(s) it is authorized to represent.
+* A numeric "public key" that mathematically corresponds to a "private key" held by the website owner.
+* A cryptographic signature by a certificate authority (CA) that vouches for the relationship between the private key and the authorized domain(s).
+* Other technical information, such when the certificate expires, and how extensively the domain was validated.
+* Optionally, information about a person or organization that owns the domain(s).
+
+Web browsers are generally set to trust a pre-selected list of certificate authorities (CAs), and the browser can verify that any signature it sees comes from a CA in that list. The list of trusted CAs is set either by the underlying operating system or by the browser itself.
+
+When a website presents a certificate to a browser during an HTTPS connection, the browser uses the information and signature in the certificate to confirm that a CA it trusts has decided to trust the website the browser is connecting to.
+
+## Getting a certificate
+
+
+
+## Certificate authorities
+
+
+
+
+## Certificate FAQ
+

--- a/pages/certificates.md
+++ b/pages/certificates.md
@@ -105,9 +105,9 @@ The strength of Certificate Transparency increases as more CAs publish more cert
 
 Domain owners can [use HPKP](https://developer.mozilla.org/en-US/docs/Web/Security/Public_Key_Pinning) in one of two ways:
 
-* The `Public-Key-Pins` header contains a list of SHA-256 hashes of public key information corresponding to client, intermediate, or root certificates. [Supporting browsers](http://caniuse.com/#search=hpkp) will hard-fail on certificates whose validated chain does not contain at least one of the listed keys. The domain owner can list a URI that browsers can POST to with error information when a hard-fail occurs.
+* The `Public-Key-Pins` header contains a list of SHA-256 hashes of public key information corresponding to client, intermediate, or root certificates. [Supporting browsers](http://caniuse.com/#search=hpkp) **will hard-fail** on certificates whose validated chain does not contain at least one of the listed keys. The domain owner can list a URI that browsers can POST to with error information when a hard-fail occurs.
 
-* The `Public-Key-Pins-Report-Only` HTTP header contains the same information, but will not fail or show users an error if a pinning violation is detected. Browsers will report detected violations to a given URI. This is
+* The `Public-Key-Pins-Report-Only` HTTP header contains the same information, but **will not fail or show users an error** if a pinning violation is detected. Browsers will report detected violations to a given URI.
 
 Using `Public-Key-Pins` is **potentially dangerous**, and mistakes can lead to a site being rendered entirely inaccessible for weeks or months.
 

--- a/pages/certificates.md
+++ b/pages/certificates.md
@@ -25,13 +25,13 @@ Technically, a certificate is a file that contains:
 
 * The domain(s) it is authorized to represent.
 * A numeric "public key" that mathematically corresponds to a "private key" held by the website owner.
-* A cryptographic signature by a certificate authority (CA) that vouches for the relationship between the private key and the authorized domain(s).
-* Other technical information, such when the certificate expires, and how extensively the domain was validated.
+* A cryptographic signature by a certificate authority (CA) that vouches for the relationship between the keypair and the authorized domain(s).
+* Other technical information, such when the certificate expires, what algorithm the CA used to sign it, and how extensively the domain was validated.
 * Optionally, information about a person or organization that owns the domain(s).
 
 Web browsers are generally set to trust a pre-selected list of certificate authorities (CAs), and the browser can verify that any signature it sees comes from a CA in that list. The list of trusted CAs is set either by the underlying operating system or by the browser itself.
 
-When a website presents a certificate to a browser during an HTTPS connection, the browser uses the information and signature in the certificate to confirm that a CA it trusts has decided to trust the website the browser is connecting to.
+When a website presents a certificate to a browser during an HTTPS connection, the browser uses the information and signature in the certificate to confirm that a CA it trusts has decided to trust the information in the certificate.
 
 ## What kind of certificate should I get for my domain?
 
@@ -97,7 +97,7 @@ The strength of Certificate Transparency increases as more CAs publish more cert
 #### Certificate Transparency Resources
 
 * [Google CT FAQ](https://www.certificate-transparency.org/faq)
-* [RFC 6962](https://tools.ietf.org/html/rfc6962), the official standard
+* [RFC 6962](https://tools.ietf.org/html/rfc6962), the experimental standard for CT
 * [Wikipedia entry](https://en.wikipedia.org/wiki/Certificate_Transparency) for CT
 
 ### HTTP Public Key Pinning

--- a/pages/certificates.md
+++ b/pages/certificates.md
@@ -42,7 +42,7 @@ In general:
 
 * Certificates can be valid for anywhere from years to days. In general, **shorter-lived certificates offer a better security posture**, since the impact of key compromise is less severe. Automating the issuance and renewal of certificates is an overall best practice, and can make the adoption of shorter-lived certificates more practical.
 
-* Agencies should **[avoid certificates signed with SHA-1](/technical-guidelines/#signature-algorithms)**, and CAs are forbidden from issuing them entirely as of January 1, 2016. Any existing certificates signed with SHA-1 should be replaced immediately, as browsers are quickly moving to remove support for the SHA-1 algorithm.
+* Agencies should [avoid certificates signed with SHA-1](/technical-guidelines/#signature-algorithms), and CAs are forbidden from issuing them entirely as of January 1, 2016. **Any existing certificates signed with SHA-1 should be replaced immediately**, as browsers are quickly moving to remove support for the SHA-1 algorithm.
 
 As a general matter, certificates from any commercial CA will meet the few [NIST technical requirements](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf) that relate to certificates.
 

--- a/pages/certificates.md
+++ b/pages/certificates.md
@@ -59,7 +59,7 @@ The Baseline Requirements only constrain CAs -- they do not constrain browser be
 
 * The current [Baseline Requirements](https://cabforum.org/baseline-requirements-documents/)
 * [CAB/Forum voting record](https://cabforum.org/ballots/)
-* [Mozilla revoking an ANSII intermediate](https://blog.mozilla.org/security/2013/12/09/revoking-trust-in-one-anssi-certificate/) after ANSII was found to have violated the BRs by inappropriately issuing a intermediate certificate for use in network monitoring.
+* [Mozilla revoking an ANSSI intermediate](https://blog.mozilla.org/security/2013/12/09/revoking-trust-in-one-anssi-certificate/) after ANSSI was found to have violated the BRs by inappropriately issuing a intermediate certificate for use in network monitoring.
 * [Google requiring Symantec to employ Certificate Transparency](https://googleonlinesecurity.blogspot.com/2015/10/sustaining-digital-certificate-security.html) after Symantec was found to have violated the BRs by misissuing certificates.
 
 ## Does the US government operate a publicly trusted certificate authority?

--- a/pages/certificates.md
+++ b/pages/certificates.md
@@ -2,7 +2,7 @@
 layout: page
 title: Certificates
 permalink: /certificates/
-description: "Guidance around certificates for use in HTTPS."
+description: "FAQ on certificates and certificate authorities for agencies migrating to HTTPS."
 ---
 
 Frequently asked questions and answers about HTTPS certificates and certificate authorities.

--- a/pages/certificates.md
+++ b/pages/certificates.md
@@ -66,7 +66,7 @@ The Baseline Requirements only constrain CAs -- they do not constrain browser be
 No, not as of late 2015, and this is unlikely to change in the near future.
 
 The [Federal PKI](http://www.idmanagement.gov/federal-public-key-infrastructure) root is trusted by some browsers and operating systems, but is not contained in the [Mozilla Trusted Root Program](https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/policy/).
-s
+
 The Federal PKI has an [open application](https://bugzilla.mozilla.org/show_bug.cgi?id=478418) to the Mozilla Trusted Root Program. However, even if the Federal PKI's application is accepted, it will take a significant amount of time for the Federal PKI's root certificate to propagate widely around the world.
 
 ## Are there federal restrictions on acceptable certificate authorities to use?

--- a/pages/certificates.md
+++ b/pages/certificates.md
@@ -8,7 +8,7 @@ description: "Guidance around certificates for use in HTTPS."
 Frequently asked questions and answers about HTTPS certificates and certificate authorities.
 
 * [What are certificates and certificate authorities?](#what-are-certificates-and-certificate-authorities?)
-* [What kind of rules and oversight are certificate authorities subject to?](#what-kind-of-rules-and-oversight-are-certificate-authorities-subject-to?)
+* [What kind of rules and oversight are certificate authorities subject to?](#what-rules-and-oversight-are-certificate-authorities-subject-to?)
 * [Does the US government operate a publicly trusted certificate authority?](#does-the-us-government-operate-a-publicly-trusted-certificate-authority?)
 * [Are there federal restrictions on acceptable certificate authorities to use?](#are-there-federal-restrictions-on-acceptable-certificate-authorities-to-use?)
 * [Then how can I limit which CAs can issue certificates for a domain?](#then-how-can-i-limit-which-cas-can-issue-certificates-for-a-domain?)
@@ -32,7 +32,21 @@ Web browsers are generally set to trust a pre-selected list of certificate autho
 
 When a website presents a certificate to a browser during an HTTPS connection, the browser uses the information and signature in the certificate to confirm that a CA it trusts has decided to trust the website the browser is connecting to.
 
-## What kind of rules and oversight are certificate authorities subject to?
+## What kind of certificate should I get for my domain?
+
+There are many kinds of certificates in use in the federal government today, and the right one may depend on a system's technical architecture or an agency's business policies.
+
+In general:
+
+* "Domain Validation" (DV) certificates are usually less expensive and more amenable to automation than "Extended Validation" (EV) certificates. EV certificates generally result in the domain owner's name appearing in the browser URL bar of visitors. **Ordinary DV certificates are completely acceptable for government use.**
+
+* Certificates can be valid for anywhere from years to days. In general, **shorter-lived certificates offer a better security posture**, since the impact of key compromise is less severe. Automating the issuance and renewal of certificates is an overall best practice, and can make the adoption of shorter-lived certificates more practical.
+
+* Agencies should **[avoid certificates signed with SHA-1](/technical-guidelines/#signature-algorithms)**, and CAs are forbidden from issuing them entirely as of January 1, 2016. Any existing certificates signed with SHA-1 should be replaced immediately, as browsers are quickly moving to remove support for the SHA-1 algorithm.
+
+As a general matter, certificates from any commercial CA will meet the few [NIST technical requirements](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf) that relate to certificates.
+
+## What rules and oversight are certificate authorities subject to?
 
 Since 2012, all major browsers and certificate authorities participate in the **[CA/Browser Forum](https://cabforum.org). Though self-regulated, the CA/Browser Forum is effectively the governing body for publicly trusted certificate authorities.
 

--- a/pages/certificates.md
+++ b/pages/certificates.md
@@ -8,7 +8,8 @@ description: "FAQ on certificates and certificate authorities for agencies migra
 Frequently asked questions and answers about HTTPS certificates and certificate authorities.
 
 * [What are certificates and certificate authorities?](#what-are-certificates-and-certificate-authorities?)
-* [What kind of rules and oversight are certificate authorities subject to?](#what-rules-and-oversight-are-certificate-authorities-subject-to?)
+* [What kind of certificate should I get for my domain?](#what-kind-of-certificate-should-i-get-for-my-domain?)
+* [What rules and oversight are certificate authorities subject to?](#what-rules-and-oversight-are-certificate-authorities-subject-to?)
 * [Does the US government operate a publicly trusted certificate authority?](#does-the-us-government-operate-a-publicly-trusted-certificate-authority?)
 * [Are there federal restrictions on acceptable certificate authorities to use?](#are-there-federal-restrictions-on-acceptable-certificate-authorities-to-use?)
 * [Then how can I limit which CAs can issue certificates for a domain?](#then-how-can-i-limit-which-cas-can-issue-certificates-for-a-domain?)

--- a/pages/faq.md
+++ b/pages/faq.md
@@ -5,6 +5,17 @@ permalink: /faq/
 description: "Frequently asked questions about HTTPS: what it does, and what it doesn't do."
 ---
 
+Below are some frequently asked questions and answers about HTTPS.
+
+* [What does HTTPS do?](#what-does-https-do?)
+* [What information does HTTPS protect?](#what-information-does-https-protect?)
+* [What information does HTTPS _not_ protect?](#what-information-does-https-not-protect?)
+* [How does migrating to HTTPS affect search engine optimization (SEO)?](#how-does-migrating-to-https-affect-search-engine-optimization-seo?)
+* [How difficult is it to attack an HTTPS connection?](#how-difficult-is-it-to-attack-an-https-connection?)
+* [Why are domain names unencrypted over HTTPS today?](#why-are-domain-names-unencrypted-over-https-today?)
+* [Why isn't DNSSEC good enough?](#why-isnt-dnssec-good-enough?)
+* [How does HTTPS protect against DNS spoofing?](#how-does-https-protect-against-dns-spoofing?)
+
 ### What does HTTPS do?
 
 When properly configured, an HTTPS connection guarantees three things:
@@ -61,15 +72,15 @@ By contrast, plain HTTP connections can be easily intercepted and modified by an
 
 ## Why are domain names unencrypted over HTTPS today?
 
-This is primarily to support **[Server Name Indication](/sni/)** (SNI), a TLS extension that allows multiple hostnames to be served over HTTPS from one IP address. 
+This is primarily to support **[Server Name Indication](/sni/)** (SNI), a TLS extension that allows multiple hostnames to be served over HTTPS from one IP address.
 
-The SNI extension was introduced in 2003 to allow HTTPS deployment to scale more easily and cheaply, but it does mean that the hostname is sent by browsers to servers "in the clear" so that the receiving IP address knows which certificate to present to the client. 
+The SNI extension was introduced in 2003 to allow HTTPS deployment to scale more easily and cheaply, but it does mean that the hostname is sent by browsers to servers "in the clear" so that the receiving IP address knows which certificate to present to the client.
 
 When a domain or a subdomain itself reveals sensitive information (e.g. 'contraception.foo.gov' or 'suicide-help.foo.gov'), this can reveal that information to passive eavesdroppers.
 
 From a network privacy perspective, DNS also "leaks" hostnames in the clear across the network today (even when DNSSEC is used). There are ongoing efforts in the network standards community to encrypt both the SNI hostname and DNS lookups, but as of late 2015, nothing has been deployed to support these goals.
 
-Most clients support SNI today, and site owners are encouraged to [evaluate the feasibility of requiring SNI support](/sni/), to save money and resources. However, whether SNI support is required to access for a specific website or not, a website's owner should consider their hostnames to be unencrypted over HTTPS, and account for this when provisioning domains and subdomains.
+Most clients support SNI today, and site owners are encouraged to [evaluate the feasibility of requiring SNI support](/sni/), to save money and resources. However, whether SNI support is required to access a specific website or not, a website's owner should consider their hostnames to be unencrypted over HTTPS, and account for this when provisioning domains and subdomains.
 
 ### Why isn't DNSSEC good enough?
 

--- a/pages/resources.md
+++ b/pages/resources.md
@@ -19,7 +19,7 @@ The DigitalGov University has two presentations on HTTPS, led by Eric Mill and G
 
 ### Tools
 
-* [`crt.sh`](https://crt.sh) - A public viewer for Certificate Transparency logs. For example, you can view [all publicly logged whitehouse.gov certificates](https://crt.sh/?q=whitehouse.gov).
+* [`crt.sh`](https://crt.sh) - An [open source](https://github.com/crtsh) public viewer for Certificate Transparency logs. For example, you can view [all publicly logged whitehouse.gov certificates](https://crt.sh/?q=whitehouse.gov).
 * [`ssllabs-scan`](https://github.com/ssllabs/ssllabs-scan) - Command line tool for the API for [SSL Labs](https://www.ssllabs.com/ssltest/), a universally referenced HTTPS evaluation and grading tool for public-facing websites.
 * [`site-inspector`](https://github.com/benbalter/site-inspector) - Scan a domain for various web/HTTP-related properties, including HTTPS support.
 * [`mixed-content-scan`](https://github.com/bramus/mixed-content-scan) - Command line tool for walking over a website and scanning for the use of insecure resources.

--- a/pages/resources.md
+++ b/pages/resources.md
@@ -19,6 +19,7 @@ The DigitalGov University has two presentations on HTTPS, led by Eric Mill and G
 
 ### Tools
 
+* [`crt.sh`](https://crt.sh) - A public viewer for Certificate Transparency logs. For example, you can view [all publicly logged whitehouse.gov certificates](https://crt.sh/?q=whitehouse.gov).
 * [`ssllabs-scan`](https://github.com/ssllabs/ssllabs-scan) - Command line tool for the API for [SSL Labs](https://www.ssllabs.com/ssltest/), a universally referenced HTTPS evaluation and grading tool for public-facing websites.
 * [`site-inspector`](https://github.com/benbalter/site-inspector) - Scan a domain for various web/HTTP-related properties, including HTTPS support.
 * [`mixed-content-scan`](https://github.com/bramus/mixed-content-scan) - Command line tool for walking over a website and scanning for the use of insecure resources.

--- a/pages/technical.md
+++ b/pages/technical.md
@@ -63,7 +63,7 @@ A part of the signature process is computing a "hash" of the data included in th
 
 SHA-1 has been shown to have serious weaknesses, and so browser and OS providers like [Google](http://googleonlinesecurity.blogspot.com/2014/09/gradually-sunsetting-sha-1.html), [Microsoft](http://blogs.technet.com/b/pki/archive/2013/11/12/sha1-deprecation-policy.aspx), and [Mozilla](https://blog.mozilla.org/security/2014/09/23/phasing-out-certificates-with-sha-1-based-signature-algorithms/) have announced timelines to deprecate SHA-1 in favor of the SHA-2 family of algorithms.
 
-[NIST has disallowed SHA-1](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf) for digital signature generation after 2013. 
+[NIST has disallowed SHA-1](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf) for digital signature generation after 2013.
 
 While details on browser and OS policies vary, site owners should generally consider SHA-1 to be technically unsupported by January 2017.
 


### PR DESCRIPTION
This pull request adds a page dedicated to `Certificates`, structured as an FAQ to address many of the issues that have come up in the federal community. This is more government-oriented than some of the other resources pages.

It includes an introduction to certificates and CAs, a description of the federal PKI, a discussion about how CAs are overseen (the CA/Browser Forum), a summary of (the lack of) federal requirements restricting CA use, and some ways in which domain owners _can_ monitor or restrain the use of certs from non-approved or unexpected CAs.

The proposed page can be viewed most easily in GitHub here:

https://github.com/GSA/https/blob/certificates/pages/certificates.md

I also added the open-source [crt.sh](https://crt.sh) to the Resources page. I also took the Table of Contents model I used for the Technical Guidelines page and the new Certificates page and added it to the general FAQ page.

There's still a bit I want to add before merging:

- [x] `What kind of certificate should I get for my domain?` (establishing that DV is fine, that short-lived certificates are fine, maybe mentioning other stuff)