### PR TITLE
Clarify some sentences and sections about certificates

### DIFF
--- a/pages/certificates.md
+++ b/pages/certificates.md
@@ -76,7 +76,7 @@ There are no government-wide rules limiting what CAs federal domains can use.
 
 It is important to understand that, while there may be technical or business reasons for an agency to limit which CAs it uses, **there is no security benefit** to limiting CAs through internal policies alone. Browsers will trust certificates acquired from any publicly trusted CA, and so limiting CA usage internally will not limit the CAs from which an attacker may obtain a forged certificate.
 
-As an analogy: consider a New York company which insists its employees only show New York photo IDs when gaining access to the secure facilities of other US companies or governments. This company's policy alone will not stop someone with a Pennsylvania ID from gaining access while pretending to work for this New York company. Every secure facility in the country must also know to insist on New York IDs for this company, and must enforce this rule.
+As an analogy: consider a New York company which insists its employees only show New York photo IDs when gaining access to the secure facilities of other US companies or governments. This company's policy alone will not stop someone with a Pennsylvania ID from gaining access while pretending to work for this New York company. For this to be effective, every secure facility in the country must also know to insist on New York IDs for this company, and must enforce this rule.
 
 In practice, federal agencies use a wide variety of publicly trusted commercial CAs and privately trusted enterprise CAs to secure their web services.
 

--- a/pages/certificates.md
+++ b/pages/certificates.md
@@ -39,7 +39,7 @@ There are many kinds of certificates in use in the federal government today, and
 
 In general:
 
-* "Domain Validation" (DV) certificates are usually less expensive and more amenable to automation than "Extended Validation" (EV) certificates. EV certificates generally result in the domain owner's name appearing in the browser URL bar of visitors. **Ordinary DV certificates are completely acceptable for government use.**
+* "Domain Validation" (DV) certificates are usually less expensive and more amenable to automation than "Extended Validation" (EV) certificates. EV certificates generally result in the domain owner's name appearing in the browser URL bar visitors see. **Ordinary DV certificates are completely acceptable for government use.**
 
 * Certificates can be valid for anywhere from years to days. In general, **shorter-lived certificates offer a better security posture**, since the impact of key compromise is less severe. Automating the issuance and renewal of certificates is an overall best practice, and can make the adoption of shorter-lived certificates more practical.
 
@@ -51,30 +51,32 @@ As a general matter, certificates from any commercial CA will meet the few [NIST
 
 Since 2012, all major browsers and certificate authorities participate in the **[CA/Browser Forum](https://cabforum.org)**. Though self-regulated, the CA/Browser Forum is effectively the governing body for publicly trusted certificate authorities.
 
-The CA/B Forum produces the **[Baseline Requirements](https://cabforum.org/baseline-requirements-documents/)** (BRs), a set of technical and procedural policies that all CAs must adhere to. These policies are determined through a [formal voting process](https://cabforum.org/ballots/) of browsers and CAs. The BRs are enforced through a combination of technical measures, a system of standard third-party audits, and the overall community's attention to publicly visible certificates.
+The CA/B Forum produces the **[Baseline Requirements](https://cabforum.org/baseline-requirements-documents/)** (BRs), a set of technical and procedural policies that all CAs must adhere to. These policies are determined through a [formal voting process](https://cabforum.org/ballots/) of browsers and CAs. The BRs are enforced through a combination of technical measures, standard third-party audits, and the overall community's attention to publicly visible certificates.
 
-The Baseline Requirements only constrain CAs -- they do not constrain browser behavior. Since browser vendors ultimately decide which certificates their browser will trust, they are the enforcers and adjudicators of BR violations. If a CA is found to be in violation of the BRs, a browser may punish that CA's ability to issue certificates that that browser will trust, up to and including expulsion from that browser's trust store.
+The Baseline Requirements only constrain CAs -- they do not constrain browser behavior. Since browser vendors ultimately decide which certificates their browser will trust, they are the enforcers and adjudicators of BR violations. If a CA is found to be in violation of the Baseline Requirements, a browser may punish that CA's ability to issue certificates that that browser will trust, up to and including expulsion from that browser's trust store.
 
 #### CA / Browser Resources
 
 * The current [Baseline Requirements](https://cabforum.org/baseline-requirements-documents/)
-* [CAB/Forum voting record](https://cabforum.org/ballots/)
-* [Mozilla revoking an ANSSI intermediate](https://blog.mozilla.org/security/2013/12/09/revoking-trust-in-one-anssi-certificate/) after ANSSI was found to have violated the BRs by inappropriately issuing a intermediate certificate for use in network monitoring.
-* [Google requiring Symantec to employ Certificate Transparency](https://googleonlinesecurity.blogspot.com/2015/10/sustaining-digital-certificate-security.html) after Symantec was found to have violated the BRs by misissuing certificates.
+* [CA/B Forum voting record](https://cabforum.org/ballots/)
+* [Mozilla revoking an ANSSI intermediate](https://blog.mozilla.org/security/2013/12/09/revoking-trust-in-one-anssi-certificate/) after ANSSI was found to have violated the Baseline Requirements by inappropriately issuing a intermediate certificate for use in network monitoring.
+* [Google requiring Symantec to employ Certificate Transparency](https://googleonlinesecurity.blogspot.com/2015/10/sustaining-digital-certificate-security.html) after Symantec was found to have violated the Baseline Requirements by misissuing certificates.
 
 ## Does the US government operate a publicly trusted certificate authority?
 
 No, not as of late 2015, and this is unlikely to change in the near future.
 
-The [Federal PKI](http://www.idmanagement.gov/federal-public-key-infrastructure) root is trusted by some browsers and operating systems, but is not contained in the [Mozilla Trusted Root Program](https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/policy/).
+The [Federal PKI](http://www.idmanagement.gov/federal-public-key-infrastructure) root is trusted by some browsers and operating systems, but is not contained in the [Mozilla Trusted Root Program](https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/policy/). The Mozilla Trusted Root Program is used by Firefox, as well as a wide variety of devices and operating systems. This means that the Federal PKI is not able to issue certificates that are trusted widely enough to secure a web service used by the general public.
 
-The Federal PKI has an [open application](https://bugzilla.mozilla.org/show_bug.cgi?id=478418) to the Mozilla Trusted Root Program. However, even if the Federal PKI's application is accepted, it will take a significant amount of time for the Federal PKI's root certificate to propagate widely around the world.
+The Federal PKI has an [open application](https://bugzilla.mozilla.org/show_bug.cgi?id=478418) to the Mozilla Trusted Root Program. However, even if the Federal PKI's application is accepted, it will take a significant amount of time for the Federal PKI's root certificate to actually be shipped onto devices and propagate widely around the world.
 
 ## Are there federal restrictions on acceptable certificate authorities to use?
 
 There are no government-wide rules limiting what CAs federal domains can use.
 
 It is important to understand that, while there may be technical or business reasons for an agency to limit which CAs it uses, **there is no security benefit** to limiting CAs through internal policies alone. Browsers will trust certificates acquired from any publicly trusted CA, and so limiting CA usage internally will not limit the CAs from which an attacker may obtain a forged certificate.
+
+As an analogy: consider a New York company which insists its employees only show New York photo IDs when gaining access to the secure facilities of other US companies or governments. This company's policy alone will not stop someone with a Pennsylvania ID from gaining access while pretending to work for this New York company. Every secure facility in the country must also know to insist on New York IDs for this company, and must enforce this rule.
 
 In practice, federal agencies use a wide variety of publicly trusted commercial CAs and privately trusted enterprise CAs to secure their web services.
 
@@ -104,17 +106,19 @@ The strength of Certificate Transparency increases as more CAs publish more cert
 
 **[HTTP Public Key Pinning](https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning)** (HPKP) allows domain owners to **tell browsers which certain keys, certs or CAs are trusted for their domain**.
 
-Domain owners can [use HPKP](https://developer.mozilla.org/en-US/docs/Web/Security/Public_Key_Pinning) in one of two ways:
+Domain owners can use HPKP in one of two ways:
 
 * The `Public-Key-Pins` header contains a list of SHA-256 hashes of public key information corresponding to client, intermediate, or root certificates. [Supporting browsers](http://caniuse.com/#search=hpkp) **will hard-fail** on certificates whose validated chain does not contain at least one of the listed keys. The domain owner can list a URI that browsers can POST to with error information when a hard-fail occurs.
 
 * The `Public-Key-Pins-Report-Only` HTTP header contains the same information, but **will not fail or show users an error** if a pinning violation is detected. Browsers will report detected violations to a given URI.
 
-Using `Public-Key-Pins` is **potentially dangerous**, and mistakes can lead to a site being rendered entirely inaccessible for weeks or months.
+Using `Public-Key-Pins` is **powerful but potentially dangerous**, as mistakes can lead to a site being rendered entirely inaccessible for weeks or months.
 
 Using `Public-Key-Pins-Report-Only` is very safe, and can provide useful information to detect potential certificate misissuance or attacks on users.
 
 Like [HSTS](/hsts/), HPKP only takes effect once the browser has visited the site once and received the HPKP header over a secure connection. HPKP preloading is possible, but as of 2015 this requires special manual coordination with browsers to do.
+
+**Note:** As currently implemented in [Chrome](https://www.chromium.org/Home/chromium-security/security-faq#TOC-How-does-key-pinning-interact-with-local-proxies-and-filters-) and [Firefox](https://wiki.mozilla.org/SecurityEngineering/Public_Key_Pinning#How_to_use_pinning), pinning rules can be overridden by locally installed root certificates. This allows device owners -- and attackers who are able to install a local root -- to intercept or modify traffic even when a web service uses HPKP.
 
 #### HPKP Resources
 
@@ -123,4 +127,4 @@ Like [HSTS](/hsts/), HPKP only takes effect once the browser has visited the sit
 * [Discussion on GitHub](https://github.com/SSLMate/sslmate/issues/10) about HPKP strategy
 * [Wikipedia entry](https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning) for HPKP
 * [Browser support](http://caniuse.com/#search=hpkp) for HPKP
-
+* [Mozilla documentation](https://developer.mozilla.org/en-US/docs/Web/Security/Public_Key_Pinning) for HPKP


### PR DESCRIPTION
This adds a few clarifications and improvements to the [Certificates FAQ](https://https.cio.gov/certificates/).

It adds a paragraph about local HPKP overrides:

> **Note:** As currently implemented in [Chrome](https://www.chromium.org/Home/chromium-security/security-faq#TOC-How-does-key-pinning-interact-with-local-proxies-and-filters-) and [Firefox](https://wiki.mozilla.org/SecurityEngineering/Public_Key_Pinning#How_to_use_pinning), pinning rules can be overridden by locally installed root certificates. This allows device owners -- and attackers who are able to install a local root -- to intercept or modify traffic even when a web service uses HPKP.

A couple sentences about the Mozilla trusted root program:

> The Mozilla Trusted Root Program is used by Firefox, as well as a wide variety of devices and operating systems. This means that the Federal PKI is not able to issue certificates that are trusted widely enough to secure a web service used by the general public.

And an analogy (adapted from @rlbmoz) for explaining why agency policies limiting CA use don't add security alone:

> As an analogy: consider a New York company which insists its employees only show New York photo IDs when gaining access to the secure facilities of other US companies or governments. This company's policy alone will not stop someone with a Pennsylvania ID from gaining access while pretending to work for this New York company. For this to be effective, every secure facility in the country must also know to insist on New York IDs for this company, and must enforce this rule.

