### PR TITLE
Rebrand the FAQ as an Introduction

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,7 @@ navigation:
   url: /everything/
 - text: Compliance Guide
   url: /guide/
-- text: FAQ
+- text: Introduction to HTTPS
   url: /faq/
 - text: Certificates
   url: /certificates/

--- a/pages/faq.md
+++ b/pages/faq.md
@@ -1,11 +1,13 @@
 ---
 layout: page
-title: HTTPS FAQ
+title: Introduction to HTTPS
 permalink: /faq/
-description: "Frequently asked questions about HTTPS: what it does, and what it doesn't do."
+description: "An introduction to HTTPS, and frequently asked questions."
 ---
 
 Below are some frequently asked questions and answers about HTTPS.
+
+For an in-depth introduction (no technical background required), check out the DigitalGov University presentation, **["An Introduction to HTTPS"](https://www.youtube.com/watch?v=d2GmcPYWm5k)**, to learn what HTTPS is and how it protects web services and users.
 
 * [What does HTTPS do?](#what-does-https-do?)
 * [What information does HTTPS protect?](#what-information-does-https-protect?)


### PR DESCRIPTION
This renames the "FAQ" sidebar entry to "Introduction to HTTPS", to be friendlier and to be more attractive to users seeking an introduction to the topic.

It also adds a link to the [Introduction to HTTPS](https://www.youtube.com/watch?v=d2GmcPYWm5k) video that @gbinal and I did for DigitalGov University, which is already linked on the [Resources page](https://https.cio.gov/resources/).

![image](https://cloud.githubusercontent.com/assets/4592/11645688/a6c9ecae-9d24-11e5-93b6-2e56a990fa5d.png)

The URL is left unchanged as `/faq/`.

Thanks @brittag for the suggestion and inspiration!