### PR TITLE
Update FAQ - provide some "pro" for DNSSEC

### DIFF
--- a/pages/faq.md
+++ b/pages/faq.md
@@ -111,7 +111,7 @@ However, DNS resolution is just one aspect of securely communicating on the inte
 
 * No major web browsers inform the user when DNSSEC validation fails, limiting its strength and enforceability.
 
-HTTPS guarantees the confidentiality and integrity of communication between client and server, and web browsers have rigorous and evolving HTTPS enforcement policies.
+HTTPS guarantees the confidentiality and integrity of communication between client and server, and web browsers have rigorous and evolving HTTPS enforcement policies. However, DNSSEC is an important component of providing assurance of *authenticity*, particularly for traffic that does not utilize HTTP, HTTPS, and HTTP2 protocols.
 
 ### How does HTTPS protect against DNS spoofing?
 


### PR DESCRIPTION
I understand the point that HTTPS provides the "all three" but the document semi-reads as though DNSSEC has *no* value, which I don''t believe to be the intention. 

Specifically, I think DNSSEC has positives such as:
* Combined with HTTPS and HTTP/2 as a "defense in depth"
* Provides "one of the legs" of support for Authenticity that benefits not HTTP* protocols.

Just didn't want the document to read like "DNSSEC isn't worth doing..."