### PR TITLE
Add language about FPKI cross-certification

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -44,7 +44,7 @@ navigation:
   url: /faq/
 - text: Certificates
   url: /certificates/
-- text: Strict Transport Security
+- text: HTTP Strict Transport Security
   url: /hsts/
 - text: Server Name Indication
   url: /sni/

--- a/pages/certificates.md
+++ b/pages/certificates.md
@@ -72,7 +72,7 @@ The Federal PKI has an [open application](https://bugzilla.mozilla.org/show_bug.
 
 The Federal PKI has ["cross-certified" other agencies and commercial CAs](http://www.idmanagement.gov/entities-cross-certified-federal-bridge), which means their roots will be trusted by clients that trust the Federal PKI. However, none of these roots are _publicly trusted_. Even when a publicly trusted commercial CA is cross-certified with the Federal PKI, they maintain complete separation between their publicly trusted roots and their Federal PKI cross-certified roots.
 
-As a result, there is not currently a viable way to obtain an individual certificate that is issued or trusted by the Federal PKI, and also trusted by the general public.
+As a result, there is not currently a viable way to obtain an individual HTTPS certificate that is issued or trusted by the Federal PKI, and also trusted by the general public.
 
 ## Are there federal restrictions on acceptable certificate authorities to use?
 

--- a/pages/certificates.md
+++ b/pages/certificates.md
@@ -70,6 +70,10 @@ The [Federal PKI](http://www.idmanagement.gov/federal-public-key-infrastructure)
 
 The Federal PKI has an [open application](https://bugzilla.mozilla.org/show_bug.cgi?id=478418) to the Mozilla Trusted Root Program. However, even if the Federal PKI's application is accepted, it will take a significant amount of time for the Federal PKI's root certificate to actually be shipped onto devices and propagate widely around the world.
 
+The Federal PKI has ["cross-certified" other agencies and commercial CAs](http://www.idmanagement.gov/entities-cross-certified-federal-bridge), which means their roots will be trusted by clients that trust the Federal PKI. However, none of these roots are _publicly trusted_. Even when a publicly trusted commercial CA is cross-certified with the Federal PKI, they maintain complete separation between their publicly trusted roots and their Federal PKI cross-certified roots.
+
+As a result, there is not currently a viable way to obtain an individual certificate that is issued or trusted by the Federal PKI, and also trusted by the general public.
+
 ## Are there federal restrictions on acceptable certificate authorities to use?
 
 There are no government-wide rules limiting what CAs federal domains can use.

--- a/pages/certificates.md
+++ b/pages/certificates.md
@@ -66,13 +66,13 @@ The Baseline Requirements only constrain CAs -- they do not constrain browser be
 
 No, not as of late 2015, and this is unlikely to change in the near future.
 
-The [Federal PKI](http://www.idmanagement.gov/federal-public-key-infrastructure) root is trusted by some browsers and operating systems, but is not contained in the [Mozilla Trusted Root Program](https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/policy/). The Mozilla Trusted Root Program is used by Firefox, as well as a wide variety of devices and operating systems. This means that the Federal PKI is not able to issue certificates that are trusted widely enough to secure a web service used by the general public.
+The [Federal PKI](http://www.idmanagement.gov/federal-public-key-infrastructure) root is trusted by some browsers and operating systems, but is not contained in the [Mozilla Trusted Root Program](https://www.mozilla.org/en-US/about/governance/policies/security-group/certs/policy/). The Mozilla Trusted Root Program is used by Firefox, as well as a wide variety of devices and operating systems. This means that the Federal PKI is not able to issue certificates for use in TLS/HTTPS that are trusted widely enough to secure a web service used by the general public.
 
 The Federal PKI has an [open application](https://bugzilla.mozilla.org/show_bug.cgi?id=478418) to the Mozilla Trusted Root Program. However, even if the Federal PKI's application is accepted, it will take a significant amount of time for the Federal PKI's root certificate to actually be shipped onto devices and propagate widely around the world.
 
-The Federal PKI has ["cross-certified" other agencies and commercial CAs](http://www.idmanagement.gov/entities-cross-certified-federal-bridge), which means their roots will be trusted by clients that trust the Federal PKI. However, none of these roots are _publicly trusted_. Even when a publicly trusted commercial CA is cross-certified with the Federal PKI, they maintain complete separation between their publicly trusted roots and their Federal PKI cross-certified roots.
+The Federal PKI has [cross-certified other agencies and commercial CAs](http://www.idmanagement.gov/entities-cross-certified-federal-bridge), which means their certificates will be trusted by clients that trust the Federal PKI. However, none of these roots are _publicly trusted_. Even when a publicly trusted commercial CA is cross-certified with the Federal PKI, they maintain complete separation between their publicly trusted certificates and their Federal PKI cross-certified certificates.
 
-As a result, there is not currently a viable way to obtain an individual HTTPS certificate that is issued or trusted by the Federal PKI, and also trusted by the general public.
+As a result, there is not currently a viable way to obtain an individual certificate for use in TLS/HTTPS that is issued or trusted by the Federal PKI, and also trusted by the general public.
 
 ## Are there federal restrictions on acceptable certificate authorities to use?
 


### PR DESCRIPTION
Because it's come up a few times now, this PR adds some language to the `/certificates/` page clarifying the [list of cross-certified FPKI entities](http://www.idmanagement.gov/entities-cross-certified-federal-bridge), to establish that even if a commercial CA is on this list, it's not their publicly trusted roots that are the ones which have been cross-signed.

The added language is:

> The Federal PKI has ["cross-certified" other agencies and commercial CAs](http://www.idmanagement.gov/entities-cross-certified-federal-bridge), which means their roots will be trusted by clients that trust the Federal PKI. However, none of these roots are _publicly trusted_. Even when a publicly trusted commercial CA is cross-certified with the Federal PKI, they maintain complete separation between their publicly trusted roots and their Federal PKI cross-certified roots.
> 
> As a result, there is not currently a viable way to obtain an individual HTTPS certificate for that is issued or trusted by the Federal PKI, and also trusted by the general public.