### PR TITLE
Add HSTS header example for the Caddy server

### DIFF
--- a/pages/hsts.md
+++ b/pages/hsts.md
@@ -110,6 +110,12 @@ On **Apache**, you would apply a `Header` directive to always set the HSTS heade
 Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
 ```
 
+Similarly, with **Caddy**, you would add a `header` directive to always set the HSTS header:
+
+```
+header / Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+```
+
 On **Microsoft systems running IIS** (Internet Information Services), there are no ".htaccess" files to implement custom headers. IIS applications use a central "web.config" file for configuration. For IIS 7.0 and up, the code is as follows:
 
 ```


### PR DESCRIPTION
Synthesizes info from https://caddyserver.com/docs/header.