### PR TITLE
Sync the in-repo nginx config with the server's

### DIFF
--- a/deploy/site.conf
+++ b/deploy/site.conf
@@ -1,9 +1,9 @@
 server {
-  listen 443 ssl spdy;
   server_name  https.cio.gov;
+  listen 443 ssl http2 default_server;
 
-  ssl_certificate      /etc/nginx/ssl/keys/https.cio.gov.chained.crt;
-  ssl_certificate_key  /etc/nginx/ssl/keys/https.cio.gov.key;
+  ssl_certificate      /etc/letsencrypt/live/pulse.cio.gov/fullchain.pem;
+  ssl_certificate_key  /etc/letsencrypt/live/pulse.cio.gov/privkey.pem;
 
   include ssl/ssl.rules;
   include headers.rules;


### PR DESCRIPTION
For convenience and documentation, the nginx vhost file for [https.cio.gov](https://https.cio.gov) is kept in this repo. This syncs it with the server, which includes the use of [HTTP/2](https://http2.github.io/) and a transition to a certificate from Let's Encrypt. The certificate was renewed this morning, and currently shares a certificate (and server) with [pulse.cio.gov](https://pulse.cio.gov).