### PR TITLE
A compliance guide FAQ answer about the use of federal certificates (e.g. FPKI and DoD)

### DIFF
--- a/pages/guide.md
+++ b/pages/guide.md
@@ -115,3 +115,5 @@ In practice, to deploy HSTS while using federally issued certificates, an agency
 
 * Federally issued certificates may be practical for web services whose users can be consistently expected to trust the issuing federal certificate authority (CA). Users whose devices do not trust the issuing CA will experience a connection failure and be unable to use the web service.
 * Federally issued certificates will not be practical for web services whose users may not always be expected to trust the issuing federal certificate authority. These web services will likely require the use of a certificate from a publicly trusted (commercial) CA.
+
+Whatever strategy an agency employs to manage the use of federally issued certificates, it should allow the practical deployment of [HSTS](/hsts/) across all of its publicly accessible websites and web services.

--- a/pages/guide.md
+++ b/pages/guide.md
@@ -19,6 +19,7 @@ This page provides implementation guidance for agencies by the White House Offic
   * [What about domains that are technically public, but in practice are only used internally?](#what-about-domains-that-are-technically-public,-but-in-practice-are-only-used-internally?)
   * [What happens to visitors using browsers that don&rsquo;t support HSTS, like older versions of Internet Explorer?](#what-happens-to-visitors-using-browsers-that-don't-support-hsts,-like-older-versions-of-internet-explorer?)
   * [This site redirects users to HTTPS -- why is Pulse saying it doesn't enforce HTTPS?](#this-site-redirects-users-to-https----why-is-pulse-saying-it-doesn't-enforce-https?)
+  * [What if I'm using a federally issued certificate -- such as from the Federal PKI or Department of Defense -- for my web service?](#what-if-i'm-using-a-federally-issued-certificate----such-as-from-the-federal-pki-or-department-of-defense----for-my-web-service?)
 
 
 ## Compliance and best practice checklist
@@ -99,3 +100,18 @@ Browsers that don't support HSTS are simply unaffected by HSTS, so there is no h
 [Pulse](https://pulse.cio.gov) looks for server-side redirects, using an appropriate HTTP response code. Sites that use client-side redirects -- such as a &lt;meta refresh&gt; tag or JavaScript -- will not be seen as redirects. To meet the M-15-13 requirement of enforcing HTTPS, agencies should employ server-side redirects (or alternatively, disable HTTP access altogether).
 
 Sites that are reachable on both a root domain (`http://agency.gov`) and their www subdomain (`http://www.agency.gov`) should perform a redirect to HTTPS in both cases. Redirecting one but not the other could also cause Pulse to indicate that a domain does not enforce HTTPS.
+
+### What if I'm using a federally issued certificate -- such as from the Federal PKI or Department of Defense -- for my web service?
+
+There are [no restrictions on acceptable certificate authorities](/certificates/#are-there-federal-restrictions-on-acceptable-certificate-authorities-to-use?) agencies might use to meet the requirements of M-15-13.
+
+However, M-15-13 requires agencies to do more than just redirect HTTP traffic to HTTPS. It also requires agencies to enable **[HTTP Strict Transport Security](/hsts/)** (HSTS), as [described above](#options-for-hsts-compliance). HSTS ensures that HTTPS is always used, and protects users from several common vulnerabilities.
+
+One important effect of HSTS is that it **disables the ability for users to click through certificate warnings** in supporting browsers. This means that **agencies cannot instruct users to click through certificate warnings** to use their web service while also complying with M-15-13.
+
+This is also consistent with security best practices, as instructing users to click through certificate warnings defeats the point of HTTPS, and will subject users to potential network attacks.
+
+In practice, to deploy HSTS while using federally issued certificates, an agency will likely need to separate its web services by hostname, based on their expected audience:
+
+* Federally issued certificates may be practical for web services whose users can be consistently expected to trust the issuing federal certificate authority (CA). Users whose devices do not trust the issuing CA will experience a connection failure and be unable to use the web service.
+* Federally issued certificates will not be practical for web services whose users may not always be expected to trust the issuing federal certificate authority. These web services will likely require the use of a certificate from a publicly trusted (commercial) CA.


### PR DESCRIPTION
This attempts to answer a commonly asked question about the use of federally issued certificates from enterprise CAs, such as the Federal PKI, Department of Defense, and other agency-operated CAs.

For context: M-15-13 isn't attempting to set policies around which CAs are appropriate to use and when. M-15-13 also doesn't require the use of any particular protocols or ciphers. M-15-13 cares only about ensuring that users of federal web services have the protections of confidentiality, authenticity, and integrity at all times. 

To that end, M-15-13's sole practical requirement for federal sites [is very simple](https://https.cio.gov/#guidelines):

_* Agencies must make all existing websites and services accessible through a secure connection (HTTPS-only, with HSTS) by December 31, 2016._

This proposed compliance FAQ answer makes clear that any CA, commercial or federal, is fine for use, consistent with our guidance on the [Certificates page](https://https.cio.gov/certificates/#are-there-federal-restrictions-on-acceptable-certificate-authorities-to-use?). 

However, the requirement to use [HSTS](https://https.cio.gov/hsts/) does introduce a practical difficulty in using federally issued certificates when a website's users can't be fully expected to have that root installed, because HSTS disables the ability for users to click through certificate warnings in supporting browsers. 

This answer describes that, and says that, practically speaking, an agency will need to separate the web services the public uses from those used by communities which consistently trust federal roots (generally this means a government-internal audience). Because [the US government does not run a publicly trusted certificate authority](/certificates/#does-the-us-government-operate-a-publicly-trusted-certificate-authority?), web services that see use by the general public are, in practice, likely to need a certificate from a publicly trusted (commercial) certificate authority.

It's worth acknowledging here that this guidance, while a straightforward outcome of M-15-13 and solidly in line with industry-wide security best practices, conflicts with practices used by some federal agencies today, particularly the Department of Defense. 

Nonetheless, OMB should adopt this answer as part of their guidance, so as to resolve any confusion around M-15-13's requirements and scope, and to meet the policy's goals of ensuring the security of federal web services for their users among the public and among the federal workforce.

In any case, feedback and discussion on this proposed answer would be very welcome. Screenshot of the rendered answer below:

![image](https://cloud.githubusercontent.com/assets/4592/14035323/1f9b7d40-f203-11e5-8626-31419b19931d.png)