### PR TITLE
Create a code inventory YAML file

### DIFF
--- a/.codeinventory.yml
+++ b/.codeinventory.yml
@@ -1,0 +1,14 @@
+name: https.cio.gov
+description: 'Website to support M-15-13 implementation and HTTPS best practices.'
+license: 'https://github.com/GSA/https/blob/master/LICENSE.md'
+openSourceProject: 1
+governmentWideReuseProject: 0
+tags:
+    - https
+    - tls
+    - policy
+    - jekyll
+    - ssl
+    - encryption
+contact:
+    email: https@cio.gov


### PR DESCRIPTION
Fixes #219, and brings the repository into compliance with GSA and OMB efforts.

I used the metadata generator on https://gsa.github.io/codeinventory-metadata-generator/, and chose the YAML output.

I selected "no" for the question about whether the site is intended for government-wide reuse, since this isn't a library or other reusable tool.