### PR TITLE
For now, update OMB M-memo links to obamawhitehouse.archives.gov URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The American people expect government websites to be secure and their interactions with those websites to be private.
 
-This site contains a web-friendly version of the White House Office of Management and Budget memorandum [M-15-13](https://www.whitehouse.gov/sites/default/files/omb/memoranda/2015/m-15-13.pdf), **"A Policy to Require Secure Connections across Federal Websites and Web Services"**, and provides technical guidance and best practices to assist in its implementation.
+This site contains a web-friendly version of the White House Office of Management and Budget memorandum [M-15-13](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2015/m-15-13.pdf), **"A Policy to Require Secure Connections across Federal Websites and Web Services"**, and provides technical guidance and best practices to assist in its implementation.
 
 **[Read the policy.](https://https.cio.gov)**
 
@@ -10,7 +10,7 @@ Please [open an issue](https://github.com/gsa/https/issues/new) to leave feedbac
 
 ### Thank You For Your Feedback
 
-This policy was open for public comment before its finalization. It received [numerous comments](https://github.com/GSA/https/issues?utf8=%E2%9C%93&q=label%3A%22Public+Comment%22+) whose thoughtfulness and feedback improved the **[final policy](https://www.whitehouse.gov/sites/default/files/omb/memoranda/2015/m-15-13.pdf)**.
+This policy was open for public comment before its finalization. It received [numerous comments](https://github.com/GSA/https/issues?utf8=%E2%9C%93&q=label%3A%22Public+Comment%22+) whose thoughtfulness and feedback improved the **[final policy](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2015/m-15-13.pdf)**.
 
 You can see what changed between the proposal and the final policy in [pull request #108](https://github.com/GSA/https/pull/108).
 

--- a/pages/guide.md
+++ b/pages/guide.md
@@ -5,7 +5,7 @@ permalink: /guide/
 description: "Guide for agencies on implementing the HTTPS transition."
 ---
 
-[M-15-13](https://www.whitehouse.gov/sites/default/files/omb/memoranda/2015/m-15-13.pdf) calls for "all publicly accessible Federal websites and web services" to only provide service through a secure connection (HTTPS), and to use [HTTP Strict Transport Security](/hsts/) (HSTS) to ensure this.
+[M-15-13](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2015/m-15-13.pdf) calls for "all publicly accessible Federal websites and web services" to only provide service through a secure connection (HTTPS), and to use [HTTP Strict Transport Security](/hsts/) (HSTS) to ensure this.
 
 This applies to all public domains and subdomains operated by the federal government, regardless of the domain suffix, as long as they are reachable over HTTP/HTTPS on the public internet.
 

--- a/pages/index.md
+++ b/pages/index.md
@@ -7,13 +7,13 @@ description: "The American people expect government websites to be secure and th
 
 The American people expect government websites to be secure and their interactions with those websites to be private.
 
-This site contains a web-friendly version of the White House Office of Management and Budget memorandum [M-15-13](https://www.whitehouse.gov/sites/default/files/omb/memoranda/2015/m-15-13.pdf), **"A Policy to Require Secure Connections across Federal Websites and Web Services"**, and provides technical guidance and best practices to assist in its implementation.
+This site contains a web-friendly version of the White House Office of Management and Budget memorandum [M-15-13](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2015/m-15-13.pdf), **"A Policy to Require Secure Connections across Federal Websites and Web Services"**, and provides technical guidance and best practices to assist in its implementation.
 
 ## Goal
 
 This Memorandum requires that all publicly accessible Federal websites and <a class="footnote" name="footnote-source-1"></a>web services [[1]](#footnote-1) only provide service through a secure connection.  The strongest privacy and integrity protection currently available for public web connections is [Hypertext Transfer Protocol Secure (HTTPS)](/faq/).
 
-This Memorandum expands upon the material in prior Office of Management and Budget (OMB) guidance found in [M-05-04](https://www.whitehouse.gov/sites/default/files/omb/memoranda/fy2005/m05-04.pdf "Policies for Federal Agency Public Websites") and relates to material in [M-08-23](https://www.whitehouse.gov/sites/default/files/omb/assets/omb/memoranda/fy2008/m08-23.pdf "Securing the Federal Government’s Domain Name System Infrastructure."). It provides guidance to agencies for making the transition to HTTPS and a deadline by which agencies must be in compliance.
+This Memorandum expands upon the material in prior Office of Management and Budget (OMB) guidance found in [M-05-04](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/fy2005/m05-04.pdf "Policies for Federal Agency Public Websites") and relates to material in [M-08-23](https://obamawhitehouse.archives.gov/sites/default/files/omb/assets/omb/memoranda/fy2008/m08-23.pdf "Securing the Federal Government’s Domain Name System Infrastructure."). It provides guidance to agencies for making the transition to HTTPS and a deadline by which agencies must be in compliance.
 
 ## Background
 

--- a/resources/implementing-https-links.md
+++ b/resources/implementing-https-links.md
@@ -6,7 +6,7 @@ See the [recorded presentation on YouTube](https://www.youtube.com/watch?v=rnM2q
 
 * [https.cio.gov FAQ on HTTPS](https://https.cio.gov/faq/)
 * [Mozilla blog post on deprecating non-secure HTTP](https://blog.mozilla.org/security/2015/04/30/deprecating-non-secure-http/)
-* [OMB Memorandum M-15-13](https://www.whitehouse.gov/sites/default/files/omb/memoranda/2015/m-15-13.pdf)
+* [OMB Memorandum M-15-13](https://obamawhitehouse.archives.gov/sites/default/files/omb/memoranda/2015/m-15-13.pdf)
 
 #### How HTTPS Works
 


### PR DESCRIPTION
While I'm sure OMB will get the links working again before long, for now the links to OMB M-memos are broken. This replaces those URLs with URLs to obamawhitehouse.archives.gov for now, until OMB gets that fixed.