### PR TITLE
Remove CT and HPKP info from certificates page

### DIFF
--- a/pages/certificates.md
+++ b/pages/certificates.md
@@ -13,10 +13,6 @@ Frequently asked questions and answers about HTTPS certificates and certificate 
 * [What rules and oversight are certificate authorities subject to?](#what-rules-and-oversight-are-certificate-authorities-subject-to%3f)
 * [Does the US government operate a publicly trusted certificate authority?](#does-the-us-government-operate-a-publicly-trusted-certificate-authority%3f)
 * [Are there federal restrictions on acceptable certificate authorities to use?](#are-there-federal-restrictions-on-acceptable-certificate-authorities-to-use%3f)
-* [Then how can I limit which CAs can issue certificates for a domain?](#then-how-can-i-limit-which-cas-can-issue-certificates-for-a-domain%3f)
-
-  * [Certificate Transparency](#certificate-transparency)
-  * [HTTP Public Key Pinning](#http-public-key-pinning)
 
 ## What are certificates and certificate authorities?
 
@@ -82,52 +78,3 @@ There are no government-wide rules limiting what CAs federal domains can use.
 It is important to understand that, while there may be technical or business reasons for an agency to limit which CAs it uses, **there is no security benefit** to limiting CAs through internal policies alone. Browsers will trust certificates acquired from any publicly trusted CA, and so limiting CA usage internally will not limit the CAs from which an attacker may obtain a forged certificate.
 
 In practice, federal agencies use a wide variety of publicly trusted commercial CAs and privately trusted enterprise CAs to secure their web services.
-
-## Then how can I limit which CAs can issue certificates for a domain?
-
-There is no simple and 100% effective way to force all browsers to only trust certificates for your domain that have been issued from a certain CA. In general, the strength of HTTPS on today's internet depends on the overall standards, competence, and accountability of the entire CA system.
-
-However, domain owners have some options to reduce the risk or impact of misissued or fraudulent certificates:
-
-### Certificate Transparency
-
-**[Certificate Transparency](https://en.wikipedia.org/wiki/Certificate_Transparency)** (CT) allows domain owners to **detect missuance of certificates after the fact**.
-
-CT allows CAs to publish some or all of the publicly trusted certificates that they issue to one or more public logs. Multiple organizations run CT logs, and it is possible to automatically monitor the logs for any certificates that are issued for any domains of interest.
-
-Comodo has released an [open source](https://github.com/crtsh) Certificate Transparency log viewer that they operate at [crt.sh](https://crt.sh). For example, it is possible to see [all recent certificates for whitehouse.gov](https://crt.sh/?q=whitehouse.gov), and [details of specific certificates](https://crt.sh/?id=7976268).
-
-The strength of Certificate Transparency increases as more CAs publish more certificates to public CT logs. Certificate Transparency is not currently a requirement for CAs -- however, as the use of CT increases, so does the viability of requiring CT for publicly issued certificates.
-
-#### Certificate Transparency Resources
-
-* [Google CT FAQ](https://www.certificate-transparency.org/faq)
-* [RFC 6962](https://tools.ietf.org/html/rfc6962), the experimental standard for CT
-* [Wikipedia entry](https://en.wikipedia.org/wiki/Certificate_Transparency) for CT
-
-### HTTP Public Key Pinning
-
-**[HTTP Public Key Pinning](https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning)** (HPKP) allows domain owners to **tell browsers which certain keys, certs or CAs are trusted for their domain**.
-
-Domain owners can use HPKP in one of two ways:
-
-* The `Public-Key-Pins` header contains a list of SHA-256 hashes of public key information corresponding to client, intermediate, or root certificates. [Supporting browsers](http://caniuse.com/#search=hpkp) **will hard-fail** on certificates whose validated chain does not contain at least one of the listed keys. The domain owner can list a URI that browsers can POST to with error information when a hard-fail occurs.
-
-* The `Public-Key-Pins-Report-Only` HTTP header contains the same information, but **will not fail or show users an error** if a pinning violation is detected. Browsers will report detected violations to a given URI.
-
-Using `Public-Key-Pins` is **powerful but potentially dangerous**, as mistakes can lead to a site being rendered entirely inaccessible for weeks or months.
-
-Using `Public-Key-Pins-Report-Only` is very safe, and can provide useful information to detect potential certificate misissuance or attacks on users.
-
-Like [HSTS](/hsts/), HPKP only takes effect once the browser has visited the site once and received the HPKP header over a secure connection. HPKP preloading is possible, but as of 2016 this requires special manual coordination with browsers to do.
-
-**Note:** As currently implemented in [Chrome](https://www.chromium.org/Home/chromium-security/security-faq#TOC-How-does-key-pinning-interact-with-local-proxies-and-filters-) and [Firefox](https://wiki.mozilla.org/SecurityEngineering/Public_Key_Pinning#How_to_use_pinning), pinning rules can be overridden by locally installed root certificates. This allows device owners -- and attackers who are able to install a local root -- to intercept or modify traffic even when a web service uses HPKP.
-
-#### HPKP Resources
-
-* [Guide to rolling out HPKP reporting](https://developers.google.com/web/updates/2015/09/HPKP-reporting-with-chrome-46?hl=en) by the Chrome team
-* [RFC 7469](https://tools.ietf.org/html/rfc7469), the official standard
-* [Discussion on GitHub](https://github.com/SSLMate/sslmate/issues/10) about HPKP strategy
-* [Wikipedia entry](https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning) for HPKP
-* [Browser support](http://caniuse.com/#search=hpkp) for HPKP
-* [Mozilla documentation](https://developer.mozilla.org/en-US/docs/Web/Security/Public_Key_Pinning) for HPKP


### PR DESCRIPTION
This removes the section about how to prevent CAs from issuing for your domain. This is mostly inspired by Chrome announcing that they intend to remove HPKP, but in general I also think it is better for federal agencies to understand that there's really no reliable way to prevent issuance by CAs they didn't approve. Even CAA is a best-effort approach that doesn't protect against full compromise, and I am concerned that blunt application of CAA in the federal government is likely to lead to more harm than good.

So given that, I've proposed just removing this section entirely. I could see some value in emphasizing CT, and would welcome suggestions of changes in that area, but I don't think it's worth presenting it as a way to prevent misissuance.