### PR TITLE
IIS 7.0+ example HSTS fix

### DIFF
--- a/pages/hsts.md
+++ b/pages/hsts.md
@@ -129,7 +129,7 @@ Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains
 
 On **Microsoft systems running IIS** (Internet Information Services), there are no ".htaccess" files to implement custom headers. IIS applications use a central `web.config` file for configuration. 
 
-For IIS 7.0 and up, the use the example `web.config` file configuration as follows to handle secure HTTP to HTTPS redirection with HSTS enabled for HTTPS:
+For IIS 7.0 and up, the example `web.config` file configuration below will handle secure HTTP to HTTPS redirection with HSTS enabled for HTTPS:
 
 ```
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Submitted edit prevents HSTS being directly applied in HTTP headers against HSTS specification section 7.12:
```
An HSTS Host MUST NOT include the STS header field in HTTP responses conveyed over non-secure transport.
```
SOURCE:  
https://tools.ietf.org/html/rfc6797#section-7.2