### PR TITLE
Tighten up build/push ignore files

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,15 @@
+compliance
+resources
+".ruby-version"
+".jekyll-metadata"
+".gitignore"
+node_modules
+todo.txt
+Staticfile
+Gemfile
+Gemfile.lock
+vendor
+README.md
+CONTRIBUTING.md
+LICENSE.md
+.nvmrc

--- a/.cfignore
+++ b/.cfignore
@@ -5,7 +5,6 @@ resources
 ".gitignore"
 node_modules
 todo.txt
-vendor
 README.md
 CONTRIBUTING.md
 LICENSE.md

--- a/.cfignore
+++ b/.cfignore
@@ -5,9 +5,6 @@ resources
 ".gitignore"
 node_modules
 todo.txt
-Staticfile
-Gemfile
-Gemfile.lock
 vendor
 README.md
 CONTRIBUTING.md

--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,7 @@ exclude:
 - ".ruby-version"
 - ".jekyll-metadata"
 - ".gitignore"
+- node_modules
 - todo.txt
 - Staticfile
 - Gemfile


### PR DESCRIPTION
The app was building and pushing way too many files. This tightens this up, especially excluding node_modules from both building and pushing.