### PR TITLE
Update FAQ to clarify referrer behavior

### DIFF
--- a/pages/faq.md
+++ b/pages/faq.md
@@ -87,9 +87,9 @@ However, this means that if a website migrates to HTTPS, any HTTP sites it links
 
 Website owners who wish to continue sending outbound referrer information to linked HTTP sites can use **[Referrer Policy](https://www.w3.org/TR/referrer-policy/)** to override browser default behavior, while retaining the privacy of HTTPS URLs.
 
-To do this, websites **should use** the [`origin-when-cross-origin`](https://www.w3.org/TR/referrer-policy/#referrer-policy-origin-when-cross-origin) policy. This will allow supporting browsers to send **only the origin** as the `Referer` header when going from an HTTPS site to an HTTP site.
+To do this, websites **should use** the [`origin-when-cross-origin`](https://www.w3.org/TR/referrer-policy/#referrer-policy-origin-when-cross-origin) policy. This will allow supporting browsers to send **only the origin** as the `Referer` header. This limited referral information applies even if both sites use HTTPS. 
 
-For example, if a user is on `https://agency.gov/help/aids.html` and clicks a link to `http://moreinformation.com`, then if `origin-when-cross-origin` is set, the browser will make an HTTP request to `http://moreinformation.com` with a `Referer` header of `https://agency.gov`.
+For example, if a user is on `https://agency.gov/help/aids.html` and clicks a link to `https://moreinformation.com`, then if `origin-when-cross-origin` is set, the browser will make an HTTP request to `https://moreinformation.com` with a `Referer` header of `https://agency.gov`.
 
 The simplest way to set this policy is by including a `<meta>` tag in the body of the HTTPS website:
 


### PR DESCRIPTION
The origin-when-cross-origin Referrer-policy HTTP header (and meta tag) limits referrer information whether or not the request downgrades the URL scheme (https-to-http vs https-to-https; see examples at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#Directives). The existing language seems to imply that a third-party website that upgrades to HTTPS can expect to receive resource URLs in their referrers after they update to HTTPS, which is not the case.

Here I propose new language to clarify what third parties should expect from the recommended referrer policy.