### PR TITLE
Updating EV cert language to remove mention of org name showing in the browser bar

### DIFF
--- a/pages/certificates.md
+++ b/pages/certificates.md
@@ -38,7 +38,7 @@ There are many kinds of certificates in use in the federal government today, and
 
 In general:
 
-* "Domain Validation" (DV) certificates are usually less expensive and more amenable to automation than "Extended Validation" (EV) certificates. EV certificates generally result in the domain owner's name appearing in the browser URL bar visitors see. **Ordinary DV certificates are completely acceptable for government use.**
+* "Domain Validation" (DV) certificates are usually less expensive and more amenable to automation than "Extended Validation" (EV) certificates. **Ordinary DV certificates are completely acceptable for government use.**
 
 * Certificates can be valid for anywhere from years to days. In general, **shorter-lived certificates offer a better security posture**, since the impact of key compromise is less severe. Automating the issuance and renewal of certificates is an overall best practice, and can make the adoption of shorter-lived certificates more practical.
 


### PR DESCRIPTION
EV certificates no longer have the organization name generally appear in the browser bar. This has already taken effect in some browsers, and others have announced that this will happen soon.

* [Firefox announcement](https://groups.google.com/d/msg/firefox-dev/6wAg_PpnlY4/C_DCyZm9AQAJ) (starting in Firefox 70)
* [Chrome announcement](https://groups.google.com/a/chromium.org/forum/#!topic/security-dev/h1bTcoTpfeI) (starting in Chrome 77) and [extended rationale](https://chromium.googlesource.com/chromium/src/+/HEAD/docs/security/ev-to-page-info.md)
*  [Apple announcement](https://cabforum.org/2018/06/06/minutes-for-ca-browser-forum-f2f-meeting-44-london-6-7-june-2018/#Apple-Root-Program-Update) (from June 2018)
* Microsoft doesn't have an announcement I'm aware of, but [this reporting states](https://www.computerworld.com/article/3431667/chrome-firefox-to-expunge-extended-validation-cert-signals.html) that "Microsoft's 'full-Chromium' Edge eschews any EV indicator". My own brief testing with Edge shows that both the current stable browser and the Chromium-based dev channel do not display an EV indicator on e.g. GitHub.com (while Chrome 76 still does).

Given this, I don't think it's accurate to convey to federal agencies that Extended Validation certificates "generally result in the domain owner's name appearing in the browser URL bar visitors see".

cc @h-m-f-t @lachellel 